### PR TITLE
Update ProcessSerialInput.cpp

### DIFF
--- a/src/ProcessSerialInput.cpp
+++ b/src/ProcessSerialInput.cpp
@@ -1,3 +1,7 @@
+// 3rd party libraries
+#include <Streaming.h>
+
+
 #include <CBUS2515.h>               // CAN controller and CBUS class
 #include <CBUSconfig.h>             // module configuration
 


### PR DESCRIPTION
Add header for Streaming library which is needed for the output from the file. Without it the example SignalTimer does not compile. John