### PR TITLE
Add a paragraph line to the library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,5 @@ sentence=Examples for using SignalControl with CBUS events.
 category=Device Control
 architectures=*
 depends=CBUS,CBUSconfig,SignalControl
+paragraph=Allows CBUS to support a variety of signals with different aspects. Also contains code to control the signals from sensors such as point(turnout) direction and track occupancy.
 url=https://github.com/SvenRosvall/CbusSignalControl.git


### PR DESCRIPTION
I have had error messages from the Arduino IDE 1.8.19 saying that this library is not properly formed as it has no paragraph line in the library properties file.  This change adds such a line and the error message has gone away. John